### PR TITLE
Script and document build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM rust:alpine
+
+RUN apk add openssl-libs-static pkgconf musl-dev openssl-dev

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.DEFAULT_GOAL := help
+SHELL:=/bin/bash
+
+## Build static binary at target/debug/asfd, requires docker.
+## Choose profile with variable PROFILE (dev, release,test,bench). Default = dev
+linux-static:
+	docker build -t asfd-build .
+	docker run -v $$PWD:/asfd -w /asfd -u "$$(id -u):$$(id -g)" -it --rm asfd-build ash -c "OPENSSL_STATIC=1  OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include cargo build $${PROFILE:+--$${PROFILE}}"
+
+help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
+	@echo
+	@sed -n -e "/^## / { \
+		h; \
+		s/.*//; \
+		:doc" \
+		-e "H; \
+		n; \
+		s/^## //; \
+		t doc" \
+		-e "s/:.*//; \
+		G; \
+		s/\\n## /---/; \
+		s/\\n/ /g; \
+		p; \
+	}" ${MAKEFILE_LIST} \
+	| LC_ALL='C' sort --ignore-case \
+	| awk -F '---' \
+		-v ncol=$$(tput cols) \
+		-v indent=19 \
+		-v col_on="$$(tput setaf 6)" \
+		-v col_off="$$(tput sgr0)" \
+	'{ \
+		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
+		n = split($$2, words, " "); \
+		line_length = ncol - indent; \
+		for (i = 1; i <= n; i++) { \
+			line_length -= length(words[i]) + 1; \
+			if (line_length <= 0) { \
+				line_length = ncol - indent - length(words[i]) - 1; \
+				printf "\n%*s ", -indent, " "; \
+			} \
+			printf "%s ", words[i]; \
+		} \
+		printf "\n"; \
+	}' \
+	| more $(shell test $(shell uname) == Darwin && echo '--no-init --raw-control-chars')

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# About
+
+# Building
+
+## Dynamic linking on Linux
+You can build a dynamically linked version on Linux with these pre-requisites:
+
+* Rust toolchain, see for example [Rustup.rs](https://rustup.rs/)
+* pkg-config ([how to install](https://command-not-found.com/pkg-config))
+* OpenSSL lib and headers ([how to install](https://docs.rs/openssl/0.10.16/openssl/#automatic))
+
+and then run `cargo build` (this uses the `dev` [profile](https://doc.rust-lang.org/cargo/reference/profiles.html)). The binary can then be found in `target/debug/asfd`
+
+## Static linking on Linux
+
+We provide a convenient Dockerfile to build a static binary. You can just run `make linux-static` and it will build a Docker image named `asfd-build` based on the official Rust Alpine container image. It will then use that image to build a static binary. You can choose the build [profile](https://doc.rust-lang.org/cargo/reference/profiles.html) with the `PROFILE` variable, eg `PROFILE=release make linux-static` and the binary will then be found at `target/debug/asfd`.


### PR DESCRIPTION
Adds a makefile to build a static version on linux, as just running `cargo build` will use a dynamically linked openssl.  It uses a container with an Rust Alpine linux image to have a static version of the openssl libs and a musl-based system to ensure a fully static binary is generated.