### PR TITLE
fix: do not support unrecommended hashing algos

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -14,8 +14,6 @@ pub enum ChecksumError {
 
 #[derive(Debug)]
 pub enum ChecksumAlgorithm {
-    MD5,
-    SHA1,
     SHA256,
     SHA512,
 }
@@ -23,8 +21,6 @@ pub enum ChecksumAlgorithm {
 impl ChecksumAlgorithm {
     fn infer(value: &str) -> Option<Self> {
         match value.len() {
-            32 => Some(ChecksumAlgorithm::MD5),
-            40 => Some(ChecksumAlgorithm::SHA1),
             64 => Some(ChecksumAlgorithm::SHA256),
             128 => Some(ChecksumAlgorithm::SHA512),
             _ => None,
@@ -33,8 +29,6 @@ impl ChecksumAlgorithm {
 
     fn into_digest(self) -> Box<dyn DynDigest> {
         match self {
-            ChecksumAlgorithm::MD5 => Box::new(md5::Md5::new()),
-            ChecksumAlgorithm::SHA1 => Box::new(sha1::Sha1::new()),
             ChecksumAlgorithm::SHA256 => Box::new(sha2::Sha256::new()),
             ChecksumAlgorithm::SHA512 => Box::new(sha2::Sha512::new()),
         }


### PR DESCRIPTION
MD5 and SHA-1 are unrecommended these days (links below). As it is unlikely we will deal with legacy data, it is better to remove them, otherwise risking to allow the use of insecure algorithms.

* https://www.rfc-editor.org/rfc/rfc9155.html
* https://csrc.nist.gov/pubs/sp/800/131/a/r2/final