### PR TITLE
ci: update release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: rust


### PR DESCRIPTION
To fix:

> google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.